### PR TITLE
Fixed libX11-devel dependency [ci skip]

### DIFF
--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -46,7 +46,7 @@ source run_conda_forge_build_setup
 # "recipe/yum_requirements.txt" file. After updating that file,
 # run "conda smithy rerender" and this line be updated
 # automatically.
-yum install -y csh imake libx11-devel libXaw-devel libXmu-devel byacc flex flex-devel
+yum install -y csh imake libX11-devel libXaw-devel libXmu-devel byacc flex flex-devel
 
 
 # Embarking on 1 case(s).

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,6 +1,6 @@
 csh
 imake
-libx11-devel
+libX11-devel
 libXaw-devel
 libXmu-devel
 byacc


### PR DESCRIPTION
The package was previously listed as libx11-devel, but that package doesn't exist in the yum repositories.

The build is currently passing, so perhaps explicitly listing libX11-devel as a dependency isn't really necessary in the build image.