### PR TITLE
Manually add "brew cask install xquartz" to .travis.yml (Proof-of-concept)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 language: generic
 
 os: osx
-osx_image: beta-xcode6.1
+osx_image: xcode6.4
 
 env:
   global:
@@ -14,18 +14,32 @@ env:
 
 before_install:
     # Remove homebrew.
-    - brew remove --force $(brew list)
-    - brew cleanup -s
-    - rm -rf $(brew --cache)
+    - |
+      echo ""
+      echo "Removing homebrew from Travis CI to avoid conflicts."
+      curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
+      chmod +x ~/uninstall_homebrew
+      ~/uninstall_homebrew -fq
+      rm ~/uninstall_homebrew
+
 
 install:
+    # Install Miniconda.
     - |
+      echo ""
+      echo "Installing a fresh version of Miniconda."
       MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
       curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
+    # Configure conda.
+    - |
+      echo ""
+      echo "Configuring conda."
       source /Users/travis/miniconda3/bin/activate root
+      conda config --remove channels defaults
+      conda config --add channels defaults
       conda config --add channels conda-forge
       conda config --set show_channel_urls true
       conda install --yes --quiet conda-forge-build-setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ env:
 
 
 before_install:
+    # Proof-of-concept XQuartz installation
+    - brew cask install xquartz
     # Remove homebrew.
     - |
       echo ""

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) conda-forge
+Copyright (c) 2015-2017, conda-forge
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -14,7 +14,7 @@ config=$(cat <<CONDARC
 
 channels:
  - conda-forge
- - defaults # As we need conda-build
+ - defaults
 
 conda-build:
  root-dir: /feedstock_root/build_artefacts
@@ -25,8 +25,8 @@ CONDARC
 )
 
 cat << EOF | docker run -i \
-                        -v ${RECIPE_ROOT}:/recipe_root \
-                        -v ${FEEDSTOCK_ROOT}:/feedstock_root \
+                        -v "${RECIPE_ROOT}":/recipe_root \
+                        -v "${FEEDSTOCK_ROOT}":/feedstock_root \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \
                         bash || exit $?

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -22,9 +22,6 @@ fi
 
 mkdir triangle_tmp && cd triangle_tmp && curl -q http://www.netlib.org/voronoi/triangle.shar | sh && mv triangle.? ../ni/src/lib/hlu/. && cd -
 
-# add "-std=c99" to compile config files -- not needed after NCL 6.3.0
-sed -e "s/^\(#define CcOptions.*\)$/\1 -std=c99/" -i.backup "${conf_file}"
-
 # fix path to cpp in ymake -- we should fix this in NCL
 sed -e "s|^\(  set cpp = \)/lib/cpp$|\1${PREFIX}/bin/cpp|g" -i.backup config/ymake
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -21,6 +21,8 @@ elif [ "$(uname)" = "Linux" ]; then
     conf_file=config/LINUX
 fi
 
+export EXTRA_LDFLAGS="$LDFLAGS"
+
 mkdir triangle_tmp && cd triangle_tmp && curl -q http://www.netlib.org/voronoi/triangle.shar | sh && mv triangle.? ../ni/src/lib/hlu/. && cd -
 
 # fix path to cpp in ymake -- we should fix this in NCL

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -15,6 +15,7 @@ if [ "$(uname)" = "Darwin" ]; then
         exit
     fi
 
+    LDFLAGS="-headerpad_max_install_names $LDFLAGS"
     conf_file=config/Darwin_Intel
 elif [ "$(uname)" = "Linux" ]; then
     conf_file=config/LINUX

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,11 +60,14 @@ requirements:
         - bzip2 1.0.*
         - gsl
         - pixman 0.34.*
+        - esmf
 
 test:
+    source_files:
+        - install/make-tarfile/check_files
     commands:
-        - ncl -V
-        - NCARG_ROOT=${PREFIX} ${SRC_DIR}/install/make-tarfile/check_files | grep '^<' | grep -v '^< bin/ESMF_RegridWeightGen' && exit 1 || exit 0
+        - test "$(ncl -V)" = "{{ version }}"
+        - NCARG_ROOT=${PREFIX} install/make-tarfile/check_files | grep -qv '^<'
 
 about:
     home: http://ncl.ucar.edu/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,43 +24,42 @@ requirements:
         - hdfeos2
         - hdfeos5
         - jasper
-        - libpng >=1.6.23,<1.7
+        - libpng >=1.6.28,<1.7
         - jpeg 9*
         - zlib 1.2.*
         - hdf4
         - hdf5 1.8.17|1.8.17.*
         - libiconv
         - curl
-        - cairo  # [linux]
-        - freetype 2.6.*  # [linux]
+        - cairo 1.14.*  # [linux]
+        - freetype 2.7|2.7.*  # [linux]
         - udunits2
         - bzip2 1.0.*
         - gsl
         - pkg-config
-        - pixman
+        - pixman 0.34.*
     run:
         - libgcc
         - libnetcdf 4.4.*
-        - hdf4
         - proj4 4.9.3
         - gdal 2.1.*
         - g2clib 1.6.*
         - hdfeos2
         - hdfeos5
         - jasper
-        - libpng >=1.6.23,<1.7
+        - libpng >=1.6.28,<1.7
         - jpeg 9*
         - zlib 1.2.*
         - hdf4
         - hdf5 1.8.17|1.8.17.*
         - libiconv
         - curl
-        - cairo  # [linux]
-        - freetype 2.6.*  # [linux]
+        - cairo 1.14.*  # [linux]
+        - freetype 2.7|2.7.*  # [linux]
         - udunits2
         - bzip2 1.0.*
         - gsl
-        - pixman
+        - pixman 0.34.*
 
 test:
     commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "6.3.0" %}
+{% set version = "6.4.0" %}
 
 package:
     name: ncl
@@ -7,10 +7,10 @@ package:
 source:
     fn: ncl-{{ version }}.tar.gz
     url: https://github.com/NCAR/ncl/archive/{{ version }}.tar.gz
-    sha256: d2cd8a1de1c498c1832f0765113ad58086d1d3b29bf5d2cc9b1ba60f1919951c
+    sha256: 0962ae1a1d716b182b3b27069b4afe66bf436c64c312ddfcf5f34d4ec60153c8
 
 build:
-    number: 2
+    number: 0
     skip: True  # [win]
     detect_binary_files_with_prefix: true
 


### PR DESCRIPTION
This PR circumvents conda-smithy to re-enable XQuartz in the Travis CI build environment. This is meant as a proof-of-concept test, and should not be merged into the actual feedstock.
