### PR TITLE
Pin gdal 2.1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ env:
 
 
 before_install:
-    # Proof-of-concept XQuartz installation
-    - brew cask install xquartz
     # Fast finish the PR.
     - |
       (curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py | \

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ env:
 
 
 before_install:
+    # Proof-of-concept XQuartz installation
+    - brew cask install xquartz
     # Fast finish the PR.
     - |
       (curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py | \

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -62,7 +62,7 @@ source run_conda_forge_build_setup
 # "recipe/yum_requirements.txt" file. After updating that file,
 # run "conda smithy rerender" and this line be updated
 # automatically.
-/usr/bin/sudo -n yum install -y csh imake libX11-devel libXaw-devel libXmu-devel byacc flex flex-devel
+/usr/bin/sudo -n yum install -y csh
 
 
 # Embarking on 1 case(s).

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,6 +7,13 @@ export CPPFLAGS="-I${PREFIX}/include $CPPFLAGS"
 export CFLAGS="-I${PREFIX}/include $CFLAGS"
 
 if [ "$(uname)" = "Darwin" ]; then
+    if [ -d "/opt/X11" ]; then
+        x11_lib="-L/opt/X11/lib"
+        x11_inc="-I/opt/X11/include -I/opt/X11/include/freetype2"
+    else
+        echo "No X11 libs found. Exiting..." 1>&2
+        exit
+    fi
     LDFLAGS="-headerpad_max_install_names $LDFLAGS"
     conf_file=config/Darwin_Intel
 elif [ "$(uname)" = "Linux" ]; then

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,14 +7,6 @@ export CPPFLAGS="-I${PREFIX}/include $CPPFLAGS"
 export CFLAGS="-I${PREFIX}/include $CFLAGS"
 
 if [ "$(uname)" = "Darwin" ]; then
-    if [ -d "/opt/X11" ]; then
-        x11_lib="-L/opt/X11/lib"
-        x11_inc="-I/opt/X11/include -I/opt/X11/include/freetype2"
-    else
-        echo "No X11 libs found. Exiting..." 1>&2
-        exit
-    fi
-
     LDFLAGS="-headerpad_max_install_names $LDFLAGS"
     conf_file=config/Darwin_Intel
 elif [ "$(uname)" = "Linux" ]; then

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -35,7 +35,6 @@ sed -e "s|\${PREFIX}|${PREFIX}|g" -e "s|\${x11_inc}|${x11_inc}|g" -e "s|\${x11_l
 
 echo -e "n\n" | ./Configure
 make Everything
-
 ACTIVATE_DIR="$PREFIX/etc/conda/activate.d"
 DEACTIVATE_DIR="$PREFIX/etc/conda/deactivate.d"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,62 +21,64 @@ requirements:
   build:
     - gcc
     - blas 1.1 {{ variant }}  # [not win]
-    - libnetcdf 4.4.*
-    - proj4 4.9.3
-    - libgdal 2.1.*
+    - bzip2 1.0.*
+    - cairo 1.14.*  # [linux]
+    - curl
+    - flex  # [linux]
+    - freetype 2.7  # [linux]
     - g2clib 1.6.*
+    - gsl
+    - hdf4
+    - hdf5 1.8.18|1.8.18.*
     - hdfeos2
     - hdfeos5
     - jasper
-    - libpng >=1.6.28,<1.7
     - jpeg 9*
-    - zlib 1.2.8
-    - hdf4
-    - hdf5 1.8.18|1.8.18.*
+    - libgdal 2.1.*
     - libiconv
-    - curl
-    - cairo 1.14.*  # [linux]
-    - freetype 2.7  # [linux]
-    - udunits2
-    - bzip2 1.0.*
-    - gsl
-    - pkg-config
+    - libnetcdf 4.4.*
+    - libpng >=1.6.28,<1.7
     - pixman 0.34.*
+    - pkg-config
+    - proj4 4.9.3
+    - udunits2
+    - xorg-imake  # [linux]
     - xorg-libx11  # [linux]
     - xorg-libxaw  # [linux]
     - xorg-libxmu  # [linux]
     - xorg-libxrender  # [linux]
-    - xorg-imake  # [linux]
-    - flex  # [linux]
+    - xorg-makedepend  # [linux]
+    - zlib 1.2.8
   run:
     - libgcc
     - blas 1.1 {{ variant }}  # [not win]
-    - libnetcdf 4.4.*
-    - proj4 4.9.3
-    - libgdal 2.1.*
+    - bzip2 1.0.*
+    - cairo 1.14.*  # [linux]
+    - curl
+    - esmf
+    - freetype 2.7  # [linux]
     - g2clib 1.6.*
+    - gsl
+    - hdf4
+    - hdf5 1.8.18|1.8.18.*
     - hdfeos2
     - hdfeos5
     - jasper
-    - libpng >=1.6.28,<1.7
     - jpeg 9*
-    - zlib 1.2.8
-    - hdf4
-    - hdf5 1.8.18|1.8.18.*
+    - libgdal 2.1.*
     - libiconv
-    - curl
-    - cairo 1.14.*  # [linux]
-    - freetype 2.7  # [linux]
-    - udunits2
-    - bzip2 1.0.*
-    - gsl
+    - libnetcdf 4.4.*
+    - libpng >=1.6.28,<1.7
     - pixman 0.34.*
-    - esmf
+    - proj4 4.9.3
+    - udunits2
+    - xorg-imake  # [linux]
     - xorg-libx11  # [linux]
     - xorg-libxaw  # [linux]
     - xorg-libxmu  # [linux]
     - xorg-libxrender  # [linux]
-    - xorg-imake  # [linux]
+    - xorg-makedepend  # [linux]
+    - zlib 1.2.8
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 0962ae1a1d716b182b3b27069b4afe66bf436c64c312ddfcf5f34d4ec60153c8
 
 build:
-  number: 3
+  number: 4
   skip: True  # [win]
   detect_binary_files_with_prefix: true
 
@@ -19,7 +19,7 @@ requirements:
     - gcc
     - libnetcdf 4.4.*
     - proj4 4.9.3
-    - libgdal 2.2.*
+    - libgdal 2.1.*
     - g2clib 1.6.*
     - hdfeos2
     - hdfeos5
@@ -42,7 +42,7 @@ requirements:
     - libgcc
     - libnetcdf 4.4.*
     - proj4 4.9.3
-    - libgdal 2.2.*
+    - libgdal 2.1.*
     - g2clib 1.6.*
     - hdfeos2
     - hdfeos5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,10 +22,10 @@ requirements:
     - gcc
     - blas 1.1 {{ variant }}  # [not win]
     - bzip2 1.0.*
-    - cairo 1.14.*  # [linux]
+    - cairo 1.14.*
     - curl
-    - flex  # [linux]
-    - freetype 2.7  # [linux]
+    - flex
+    - freetype 2.7
     - g2clib 1.6.*
     - gsl
     - hdf4
@@ -42,21 +42,21 @@ requirements:
     - pkg-config
     - proj4 4.9.3
     - udunits2
-    - xorg-imake  # [linux]
-    - xorg-libx11  # [linux]
-    - xorg-libxaw  # [linux]
-    - xorg-libxmu  # [linux]
-    - xorg-libxrender  # [linux]
-    - xorg-makedepend  # [linux]
+    - xorg-imake
+    - xorg-libx11
+    - xorg-libxaw
+    - xorg-libxmu
+    - xorg-libxrender
+    - xorg-makedepend
     - zlib 1.2.8
   run:
     - libgcc
     - blas 1.1 {{ variant }}  # [not win]
     - bzip2 1.0.*
-    - cairo 1.14.*  # [linux]
+    - cairo 1.14.*
     - curl
     - esmf
-    - freetype 2.7  # [linux]
+    - freetype 2.7
     - g2clib 1.6.*
     - gsl
     - hdf4
@@ -72,12 +72,12 @@ requirements:
     - pixman 0.34.*
     - proj4 4.9.3
     - udunits2
-    - xorg-imake  # [linux]
-    - xorg-libx11  # [linux]
-    - xorg-libxaw  # [linux]
-    - xorg-libxmu  # [linux]
-    - xorg-libxrender  # [linux]
-    - xorg-makedepend  # [linux]
+    - xorg-imake
+    - xorg-libx11
+    - xorg-libxaw
+    - xorg-libxmu
+    - xorg-libxrender
+    - xorg-makedepend
     - zlib 1.2.8
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,6 @@ package:
   version: {{ version }}
 
 source:
-  fn: ncl-{{ version }}.tar.gz
   url: https://github.com/NCAR/ncl/archive/{{ version }}.tar.gz
   sha256: 0962ae1a1d716b182b3b27069b4afe66bf436c64c312ddfcf5f34d4ec60153c8
 
@@ -22,7 +21,7 @@ requirements:
     - gcc
     - blas 1.1 {{ variant }}  # [not win]
     - bzip2 1.0.*
-    - cairo 1.14.*
+    - cairo 1.14.*  # [linux]
     - curl
     - flex
     - freetype 2.7
@@ -53,7 +52,7 @@ requirements:
     - libgcc
     - blas 1.1 {{ variant }}  # [not win]
     - bzip2 1.0.*
-    - cairo 1.14.*
+    - cairo 1.14.*  # [linux]
     - curl
     - esmf
     - freetype 2.7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - cairo 1.14.*  # [linux]
     - curl
     - flex
-    - freetype 2.7
+    - freetype 2.7  # [linux]
     - g2clib 1.6.*
     - gsl
     - hdf4
@@ -41,12 +41,12 @@ requirements:
     - pkg-config
     - proj4 4.9.3
     - udunits2
-    - xorg-imake
-    - xorg-libx11
-    - xorg-libxaw
-    - xorg-libxmu
-    - xorg-libxrender
-    - xorg-makedepend
+    - xorg-imake  # [linux]
+    - xorg-libx11  # [linux]
+    - xorg-libxaw  # [linux]
+    - xorg-libxmu  # [linux]
+    - xorg-libxrender  # [linux]
+    - xorg-makedepend  # [linux]
     - zlib 1.2.8
   run:
     - libgcc
@@ -55,7 +55,7 @@ requirements:
     - cairo 1.14.*  # [linux]
     - curl
     - esmf
-    - freetype 2.7
+    - freetype 2.7  # [linux]
     - g2clib 1.6.*
     - gsl
     - hdf4
@@ -71,12 +71,12 @@ requirements:
     - pixman 0.34.*
     - proj4 4.9.3
     - udunits2
-    - xorg-imake
-    - xorg-libx11
-    - xorg-libxaw
-    - xorg-libxmu
-    - xorg-libxrender
-    - xorg-makedepend
+    - xorg-imake  # [linux]
+    - xorg-libx11  # [linux]
+    - xorg-libxaw  # [linux]
+    - xorg-libxmu  # [linux]
+    - xorg-libxrender  # [linux]
+    - xorg-makedepend  # [linux]
     - zlib 1.2.8
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,18 +26,24 @@ requirements:
     - jasper
     - libpng >=1.6.28,<1.7
     - jpeg 9*
-    - zlib 1.2.*
+    - zlib 1.2.8
     - hdf4
     - hdf5 1.8.18|1.8.18.*
     - libiconv
     - curl
     - cairo 1.14.*  # [linux]
-    - freetype 2.7|2.7.*  # [linux]
+    - freetype 2.7  # [linux]
     - udunits2
     - bzip2 1.0.*
     - gsl
     - pkg-config
     - pixman 0.34.*
+    - xorg-libx11  # [linux]
+    - xorg-libxaw  # [linux]
+    - xorg-libxmu  # [linux]
+    - xorg-libxrender  # [linux]
+    - xorg-imake  # [linux]
+    - flex  # [linux]
   run:
     - libgcc
     - libnetcdf 4.4.*
@@ -49,18 +55,23 @@ requirements:
     - jasper
     - libpng >=1.6.28,<1.7
     - jpeg 9*
-    - zlib 1.2.*
+    - zlib 1.2.8
     - hdf4
     - hdf5 1.8.18|1.8.18.*
     - libiconv
     - curl
     - cairo 1.14.*  # [linux]
-    - freetype 2.7|2.7.*  # [linux]
+    - freetype 2.7  # [linux]
     - udunits2
     - bzip2 1.0.*
     - gsl
     - pixman 0.34.*
     - esmf
+    - xorg-libx11  # [linux]
+    - xorg-libxaw  # [linux]
+    - xorg-libxmu  # [linux]
+    - xorg-libxrender  # [linux]
+    - xorg-imake  # [linux]
     # This will ensure that ncl works regardles of the gsl downloaded
     # (with or without openblas) at build time.
     # We can remove this once we have a better solution.
@@ -78,6 +89,7 @@ test:
 about:
   home: http://ncl.ucar.edu/
   license: 'NCL Source Code'
+  license_file: COPYING
   summary: 'NCAR Command Language'
 
 extra:

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,8 +1,1 @@
 csh
-imake
-libX11-devel
-libXaw-devel
-libXmu-devel
-byacc
-flex
-flex-devel


### PR DESCRIPTION
Unfortunately `fiona` is not compatible with `gdal 2.2.*` yet, so we need to pin everything to `2.1.*` is we want to install them along side with `fiona`. Note that installing the previous build number with latest `gdal` is still possible when not installing `fiona`.

(I also updated the pinning and I am trying to build with xorg instead of relying on `yum` requirements.)