### PR TITLE
Fix libgdal pin and add gsl pin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,13 +28,13 @@ requirements:
     - hdfeos2
     - hdfeos5
     - jasper
-    - libpng >=1.6.28,<1.7
+    - libpng >=1.6.22,<1.6.31
     - jpeg 9*
-    - zlib 1.2.8
+    - zlib 1.2.11
     - hdf4
     - hdf5 1.8.18|1.8.18.*
     - libiconv
-    - curl
+    - curl >=7.44.0,<8
     - cairo 1.14.*  # [linux]
     - freetype 2.7  # [linux]
     - udunits2
@@ -52,13 +52,13 @@ requirements:
     - hdfeos2
     - hdfeos5
     - jasper
-    - libpng >=1.6.28,<1.7
+    - libpng >=1.6.22,<1.6.31
     - jpeg 9*
-    - zlib 1.2.8
+    - zlib 1.2.11
     - hdf4
     - hdf5 1.8.18|1.8.18.*
     - libiconv
-    - curl
+    - curl >=7.44.0,<8
     - cairo 1.14.*  # [linux]
     - freetype 2.7  # [linux]
     - udunits2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 0962ae1a1d716b182b3b27069b4afe66bf436c64c312ddfcf5f34d4ec60153c8
 
 build:
-  number: 5
+  number: 6
   skip: True  # [win]
   features:
     - blas_{{ variant }}  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - blas 1.1 {{ variant }}  # [not win]
     - libnetcdf 4.4.*
     - proj4 4.9.3
-    - libgdal 2.2.*
+    - libgdal 2.1.*
     - g2clib 1.6.*
     - hdfeos2
     - hdfeos5
@@ -47,7 +47,7 @@ requirements:
     - blas 1.1 {{ variant }}  # [not win]
     - libnetcdf 4.4.*
     - proj4 4.9.3
-    - libgdal 2.2.*
+    - libgdal 2.1.*
     - g2clib 1.6.*
     - hdfeos2
     - hdfeos5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ requirements:
     - freetype 2.7  # [linux]
     - udunits2
     - bzip2 1.0.*
-    - gsl
+    - gsl 2.2.*
     - pkg-config
     - pixman 0.34.*  # [linux]
   run:
@@ -63,7 +63,7 @@ requirements:
     - freetype 2.7  # [linux]
     - udunits2
     - bzip2 1.0.*
-    - gsl
+    - gsl 2.2.*
     - pixman 0.34.*  # [linux]
     - esmf
 


### PR DESCRIPTION
Updated `libgdal` pin from `2.2.*` to `2.1.*`.

Also added `2.2.*` pinning for `gsl` because earlier versions seemed to be causing issues with `blas`/`openblas`.

Finally, I think we may need to label all of the `ncl=6.4.0` tarballs on the conda-forge channel (prior to this one) as "broken".

Simply running `conda install -c conda-forge ncl` seems to be giving `ncl=6.4.0=3` (the broken build that initially prompted `blas`/`openblas` to be added to the recipe) higher priority than `ncl=6.4.0=blas_openblas_5`, meaning a user will install the broken `ncl=6.4.0=3` unless they explicitly specify `ncl=6.4.0=blas_openblas_5`. This was also the case with `ncl=6.4.0=blas_openblas_4`, but that build was itself broken due to `libgdal`/`kealib` issues.