### PR TITLE
Use NCL's included g2clib, remove dependency

### DIFF
--- a/recipe/Site.local.template
+++ b/recipe/Site.local.template
@@ -7,12 +7,13 @@
 #define YmakeRoot ${PREFIX}
 
 #define LibSearch ${x11_lib} -L${PREFIX}/lib -Wl,-rpath,${PREFIX}/lib
-#define IncSearch ${x11_inc} -I${PREFIX}/include -I${PREFIX}/include/freetype2
+#define IncSearch ${x11_inc} -I${grib2_dir} -I${PREFIX}/include -I${PREFIX}/include/freetype2
 
 #define BuildGDAL 1
 
 #define HDF5lib -lhdf5_hl -lhdf5 -lz
 #define NetCDF4lib  -lhdf5_hl -lhdf5
+#define GRIB2lib ${grib2_dir}/libgrib2c.a -ljasper -lpng -lz -ljpeg
 
 ${CAIROLIB}
 ${CAIROLIBUSER}

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -26,6 +26,9 @@ fi
 
 export EXTRA_LDFLAGS="$LDFLAGS"
 
+export grib2_dir=${SRC_DIR}/external/g2clib-1.6.0
+export EXTRA_INCLUDES=-I${grib2_dir}
+
 mkdir triangle_tmp && cd triangle_tmp && curl -q http://www.netlib.org/voronoi/triangle.shar | sh && mv triangle.? ../ni/src/lib/hlu/. && cd -
 
 # fix path to cpp in ymake -- we should fix this in NCL
@@ -34,7 +37,7 @@ sed -e "s|^\(  set cpp = \)/lib/cpp$|\1${PREFIX}/bin/cpp|g" -i.backup config/yma
 # fix path to cpp in $conf_file
 sed -e "s|/usr/bin/cpp|${PREFIX}/bin/cpp|g" -i.backup ${conf_file}
 
-sed -e "s|\${PREFIX}|${PREFIX}|g" -e "s|\${x11_inc}|${x11_inc}|g" -e "s|\${x11_lib}|${x11_lib}|g" -e "s|\${CAIROLIB}|${CAIROLIB}|g" -e "s|\${CAIROLIBUSER}|${CAIROLIBUSER}|g" "${RECIPE_DIR}/Site.local.template" > config/Site.local
+sed -e "s|\${PREFIX}|${PREFIX}|g" -e "s|\${x11_inc}|${x11_inc}|g" -e "s|\${x11_lib}|${x11_lib}|g" -e "s|\${CAIROLIB}|${CAIROLIB}|g" -e "s|\${CAIROLIBUSER}|${CAIROLIBUSER}|g" -e "s|\${grib2_dir}|${grib2_dir}|g" "${RECIPE_DIR}/Site.local.template" > config/Site.local
 
 echo -e "n\n" | ./Configure
 make Everything

--- a/recipe/grib2.patch
+++ b/recipe/grib2.patch
@@ -1,0 +1,26 @@
+diff --git a/external/g2clib-1.6.0/makefile b/external/g2clib-1.6.0/makefile
+index c70c4bebb..444fe1ded 100755
+--- a/external/g2clib-1.6.0/makefile
++++ b/external/g2clib-1.6.0/makefile
+@@ -18,7 +18,7 @@ DEFS=-DUSE_JPEG2000 -DUSE_PNG
+ #
+ 
+ #INC=-I/nwprod/lib/include/
+-INC=-I/usr/local/include/
++INC=-I$(PREFIX)/include/
+ 
+ #
+ #   This "C" source code contains many uses of the C++
+diff --git a/external/yMakefile b/external/yMakefile
+index 31219f27f..25115da84 100644
+--- a/external/yMakefile
++++ b/external/yMakefile
+@@ -18,7 +18,7 @@
+ #	Date:		Fri Jan 16 21:11:00 MST 2004
+ #
+ #	Description:	yMakefile for external libraries and software
+-SUBDIRS = blas lapack sphere3.1_dp  fftpack5_dp
++SUBDIRS = blas lapack sphere3.1_dp  fftpack5_dp g2clib-1.6.0
+ #define IHaveSubdirs
+ 
+ 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,11 @@ source:
   sha256: 0962ae1a1d716b182b3b27069b4afe66bf436c64c312ddfcf5f34d4ec60153c8
   patches:
     - hdf5_1.10.patch
+    - grib2.patch
 
 
 build:
-  number: 7
+  number: 8
   skip: True  # [win]
   features:
     - blas_{{ variant }}  # [not win]
@@ -26,7 +27,6 @@ requirements:
     - cairo 1.14.*  # [linux]
     - curl >=7.44.0,<8
     - freetype 2.8.1  # [linux]
-    - g2clib 1.6.*
     - gsl  2.2.*
     - hdf4
     - hdf5 1.10.1
@@ -51,7 +51,6 @@ requirements:
     - cairo 1.14.*  # [linux]
     - curl >=7.44.0,<8
     - freetype 2.8.1  # [linux]
-    - g2clib 1.6.*
     - gsl  2.2.*
     - hdf4
     - hdf5 1.10.1


### PR DESCRIPTION
NCL's g2clib includes several patches, including adding the ability to
read data files with longitudes [-180,180] instead of just [0,360].

This also fixes an issue with jpeg2000-compressed GRIB2 files.