### PR TITLE
Fixed g2clib linking

### DIFF
--- a/recipe/Site.local.template
+++ b/recipe/Site.local.template
@@ -14,6 +14,8 @@
 #define HDF5lib -lhdf5_hl -lhdf5 -lz
 #define NetCDF4lib  -lhdf5_hl -lhdf5
 #define GRIB2lib ${grib2_dir}/libgrib2c.a -ljasper -lpng -lz -ljpeg
+/* libgdal contains its own libgrib2c, so the proper libgrib2c should always be linked before libgdal. */
+#define GDALlib  ${grib2_dir}/libgrib2c.a -lgdal -lproj -ljpeg
 
 ${CAIROLIB}
 ${CAIROLIBUSER}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 
 build:
-  number: 8
+  number: 9
   skip: True  # [win]
   features:
     - blas_{{ variant }}  # [not win]


### PR DESCRIPTION
Prepended "GDALlib" #define with explicit path to libgrib2c.a

libgdal provides its own libgrib2c, so NCL's libgrib2c must always be
linked before libgdal, otherwise NCL will incorrectly try to use
libgdal's internal grib2c symbols.