### PR TITLE
Debug sed command failure in Mac build

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -32,7 +32,7 @@ export EXTRA_INCLUDES=-I${grib2_dir}
 mkdir triangle_tmp && cd triangle_tmp && curl -q http://www.netlib.org/voronoi/triangle.shar | sh && mv triangle.? ../ni/src/lib/hlu/. && cd -
 
 # debugging sed issue
-sed -e 's/@sed/sed/g' -i.backup ni/src/scripts/yMakefile
+sed -e 's/+/|/g' -i.backup ni/src/scripts/yMakefile
 
 # fix path to cpp in ymake -- we should fix this in NCL
 sed -e "s|^\(  set cpp = \)/lib/cpp$|\1cpp|g" -i.backup config/ymake

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -31,6 +31,9 @@ export EXTRA_INCLUDES=-I${grib2_dir}
 
 mkdir triangle_tmp && cd triangle_tmp && curl -q http://www.netlib.org/voronoi/triangle.shar | sh && mv triangle.? ../ni/src/lib/hlu/. && cd -
 
+# debugging sed issue
+sed -e 's/@sed/sed/g' -i.backup ni/src/scripts/yMakefile
+
 # fix path to cpp in ymake -- we should fix this in NCL
 sed -e "s|^\(  set cpp = \)/lib/cpp$|\1cpp|g" -i.backup config/ymake
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   merge_build_host: True  # [osx]
-  number: 0
+  number: 1
   skip: True  # [win]
   features:
     - blas_{{ variant }}  # [not win]


### PR DESCRIPTION
ncl_filedump and ncl_convert2nc are missing from the Mac build due to a failed sed substitution.

Also bumped build number

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
