### PR TITLE
[ci skip] adding user @zklaus

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @david-ian-brown @khallock @marylhaley @ocefpaf @xylar
+* @zklaus

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -103,6 +103,7 @@ about:
 
 extra:
   recipe-maintainers:
+    - zklaus
     - khallock
     - marylhaley
     - david-ian-brown


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @zklaus as instructed in #94.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Fixes #94